### PR TITLE
refactor(vm): pass vcpu id to mmio handlers

### DIFF
--- a/src/vm.rs
+++ b/src/vm.rs
@@ -260,15 +260,19 @@ impl<H: AxVMHal, U: AxVCpuHal> AxVM<H, U> {
                     reg,
                     reg_width: _,
                 } => {
-                    let val = self
-                        .get_devices()
-                        .handle_mmio_read(*addr, (*width).into())?;
+                    let val =
+                        self.get_devices()
+                            .handle_mmio_read(*addr, (*width).into(), vcpu.id())?;
                     vcpu.set_gpr(*reg, val);
                     true
                 }
                 AxVCpuExitReason::MmioWrite { addr, width, data } => {
-                    self.get_devices()
-                        .handle_mmio_write(*addr, (*width).into(), *data as usize);
+                    self.get_devices().handle_mmio_write(
+                        *addr,
+                        (*width).into(),
+                        *data as usize,
+                        vcpu.id(),
+                    );
                     true
                 }
                 AxVCpuExitReason::IoRead { port: _, width: _ } => true,


### PR DESCRIPTION
Adding the vcpu_id parameter for read and write operations on mmio devices

axdevice: https://github.com/arceos-hypervisor/axdevice/pull/4
axdevice_base: https://github.com/arceos-hypervisor/axdevice_crates/pull/7
